### PR TITLE
Add buildinfo to app

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+buildinfo.py ident

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from datetime import datetime
 import sys
+import buildinfo
 
 # Overload std stream to local string
 class ListStream:
@@ -24,10 +25,13 @@ def homepage():
     if hasRun == False:
         main()
         hasRun = True
-    return """
+    body = """
     <h1>COGVENTS</h1>
     <p>{}</p>
     """.format("".join(x.data).replace('\n', "<br>"))
+    buildRev = "<br/><br/><i>Git revision: " + buildinfo.getRevision() + "</i>"
+    
+    return body + buildRev
 
 if __name__ == '__main__':
     app.run(debug=False)

--- a/buildinfo.py
+++ b/buildinfo.py
@@ -1,0 +1,8 @@
+# File: buildinfo.py
+# Info: Basic functions for getting build-related info.
+#       Really not-cool and lame but useful maybe.
+
+idString = "$Id$"
+def getRevision():
+  global idString
+  return idString.replace("$", "").replace("Id:", "").strip()

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,6 @@ Cogvents! Python script shenanigans.
 `[ ] Caleb`  
 `[ ] Christian`  
 `[ ] Hatch`  
-`[*] Nick` 
+`[*] Nick`  
 `[ ] Max`  
 


### PR DESCRIPTION
Really minor thing that adds buildinfo to the app, so it's clear what revision was used to run Cogvents. This will prevent errors or issues in the future, when the game gets immensely complicated. Also fix a whitespace error in the readme.